### PR TITLE
update openai-api v1.2.0

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -6,6 +6,7 @@ exports.Config = koishi_1.Schema.intersect([
     koishi_1.Schema.object({
         apikey: koishi_1.Schema.string().required().role('secret').description('OpenAI 的 API Key'),
         model: koishi_1.Schema.union([
+            'gpt-3.5-turbo',
             'text-davinci-003',
             'text-davinci-002',
             'text-davinci-001',
@@ -13,7 +14,7 @@ exports.Config = koishi_1.Schema.intersect([
             'text-babbage-001',
             'text-ada-001'
         ]).description('OpenAI 的语言模型，默认使用第一个')
-            .default('text-davinci-003'),
+            .default('gpt-3.5-turbo'),
     }).description("OpenAI 配置"),
     koishi_1.Schema.object({
         botname: koishi_1.Schema.string().description('名字')

--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -30,9 +30,9 @@ async function getReply(bprompts, username, input, config, isdebug) {
         apiKey: config.apikey,
     });
     const openai = new openai_1.OpenAIApi(configuration);
-    const completion = await openai.createCompletion({
+    const completion = await openai.createChatCompletion({
         model: config.model,
-        prompt: prompt,
+        messages: [{role: "user", content:prompt}],
         max_tokens: config.ntokens,
         temperature: config.temperature,
         presence_penalty: config.presencePenalty,
@@ -40,7 +40,7 @@ async function getReply(bprompts, username, input, config, isdebug) {
         stop: [`\n${username}：`, `\n${username}`, `${username}：`, `\n\n`],
         user: config.botname
     });
-    return completion.data.choices[0].text.trim();
+    return completion.data.choices[0].message.content.trim();
 }
 exports.getReply = getReply;
 async function getSummary(bprompts, username, config, isdebug) {
@@ -51,16 +51,16 @@ async function getSummary(bprompts, username, config, isdebug) {
         apiKey: config.apikey,
     });
     const openai = new openai_1.OpenAIApi(configuration);
-    const completion = await openai.createCompletion({
+    const completion = await openai.createChatCompletion({
         model: config.model,
-        prompt: prompt,
+        messages: [{role: "user", content:prompt}],
         max_tokens: config.ntokens * 2,
         temperature: config.temperature,
         presence_penalty: config.presencePenalty,
         frequency_penalty: config.frequencyPenalty,
         user: config.botname
     });
-    return completion.data.choices[0].text.trim();
+    return completion.data.choices[0].message.content.trim();
 }
 exports.getSummary = getSummary;
 async function getTopic(bprompts, username, summary, config, isdebug) {
@@ -71,15 +71,15 @@ async function getTopic(bprompts, username, summary, config, isdebug) {
         apiKey: config.apikey,
     });
     const openai = new openai_1.OpenAIApi(configuration);
-    const completion = await openai.createCompletion({
+    const completion = await openai.createChatCompletion({
         model: config.model,
-        prompt: prompt,
+        messages: [{role: "user", content:prompt}],
         max_tokens: config.ntokens,
         temperature: config.temperature,
         presence_penalty: config.presencePenalty,
         frequency_penalty: config.frequencyPenalty,
         user: config.botname
     });
-    return completion.data.choices[0].text.trim();
+    return completion.data.choices[0].message.content.trim();
 }
 exports.getTopic = getTopic;

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "koishi": "^4.0.0"
   },
   "dependencies": {
-    "openai": "^3.0.0",
+    "openai": "^3.2.1",
     "fs-extra": "^10.0.0"
   },
   "publishConfig": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -21,6 +21,7 @@ export const Config: Schema<Config> = Schema.intersect([
     Schema.object({
         apikey: Schema.string().required().role('secret').description('OpenAI 的 API Key'),
         model: Schema.union([
+            'gpt-3.5-turbo',
             'text-davinci-003',
             'text-davinci-002',
             'text-davinci-001',
@@ -28,7 +29,7 @@ export const Config: Schema<Config> = Schema.intersect([
             'text-babbage-001',
             'text-ada-001'
         ]).description('OpenAI 的语言模型，默认使用第一个')
-        .default('text-davinci-003'),
+        .default('gpt-3.5-turbo'),
     }).description("OpenAI 配置"),
     Schema.object({
         botname: Schema.string().description('名字')

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -29,9 +29,9 @@ export async function getReply(bprompts: string[], username: string, input: stri
       apiKey: config.apikey,
     })
     const openai = new OpenAIApi(configuration)
-    const completion = await openai.createCompletion({
+    const completion = await openai.createChatCompletion({
       model: config.model,
-      prompt: prompt,
+      messages: [{role: "user", content:prompt}],
       max_tokens: config.ntokens,
       temperature: config.temperature,
       presence_penalty: config.presencePenalty,
@@ -39,7 +39,7 @@ export async function getReply(bprompts: string[], username: string, input: stri
       stop: [`\n${username}：`, `\n${username}`, `${username}：`, `\n\n`],
       user: config.botname
     })
-    return completion.data.choices[0].text.trim()
+    return completion.data.choices[0].message.content.trim();
 }
 
 export async function getSummary(bprompts: string[], username: string, config: Config, isdebug: boolean) {
@@ -49,16 +49,16 @@ export async function getSummary(bprompts: string[], username: string, config: C
       apiKey: config.apikey,
     })
     const openai = new OpenAIApi(configuration)
-    const completion = await openai.createCompletion({
+    const completion = await openai.createChatCompletion({
       model: config.model,
-      prompt: prompt,
+      messages: [{role: "user", content:prompt}],
       max_tokens: config.ntokens * 2,
       temperature: config.temperature,
       presence_penalty: config.presencePenalty,
       frequency_penalty: config.frequencyPenalty,
       user: config.botname
     })
-    return completion.data.choices[0].text.trim()
+    return completion.data.choices[0].message.content.trim();
 }
 
 export async function getTopic(bprompts: string[], username: string, summary: string, config: Config, isdebug: boolean) {
@@ -68,14 +68,14 @@ export async function getTopic(bprompts: string[], username: string, summary: st
       apiKey: config.apikey,
     })
     const openai = new OpenAIApi(configuration)
-    const completion = await openai.createCompletion({
+    const completion = await openai.createChatCompletion({
       model: config.model,
-      prompt: prompt,
+      messages: [{role: "user", content:prompt}],
       max_tokens: config.ntokens,
       temperature: config.temperature,
       presence_penalty: config.presencePenalty,
       frequency_penalty: config.frequencyPenalty,
       user: config.botname
     })
-    return completion.data.choices[0].text.trim()
+    return completion.data.choices[0].message.content.trim();
 }


### PR DESCRIPTION
想调用最新的gpt-3.5-turbo的话需要用新的createChatCompletion接口。
[openai-api v1.2](https://github.com/openai/openai-openapi/commit/88f221442879061d9970ed453a65b973d226f15d)增加了createChatCompletion接口，我更改代码使用了这个新接口，并添加了gpt-3.5-turbo模型。
另外，openai-api被墙了，现在需要开代理才能用。

也不一定要合并我这个代码，代理问题其实挺烦的，因为openai库没有proxy选项，所以经过openai库的流量都不走代理，需要经过一些[特殊处理](https://forum.koishi.xyz/t/topic/745/13)后才能正常使用。所以也许不依赖openai直接发请求更好。